### PR TITLE
Separate positional from keyword arguments for Ruby 3 compatibility

### DIFF
--- a/lib/sullivan.rb
+++ b/lib/sullivan.rb
@@ -13,12 +13,12 @@ module Sullivan
   end
 
   class DSL < BasicObject
-    def method_missing(method_name, *args)
+    def method_missing(method_name, *args, **kwargs)
       constant_name = DSL.camelize(method_name.to_s)
 
       if ::Sullivan::Validations.const_defined?(constant_name)
         klass = ::Sullivan::Validations.const_get(constant_name)
-        klass.new(*args)
+        klass.new(*args, **kwargs)
       else
         super
       end

--- a/lib/sullivan/version.rb
+++ b/lib/sullivan/version.rb
@@ -1,3 +1,3 @@
 module Sullivan
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/sullivan.gemspec
+++ b/sullivan.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", "~> 2.3.26"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.1.5"
+  spec.add_development_dependency "rspec", "~> 3.12.0"
 end


### PR DESCRIPTION
@Peeja Could you please release `0.0.3` with this fix?

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/